### PR TITLE
Add config to use MP Order Number as Name during Shopify order placement

### DIFF
--- a/resources/json_schema.json
+++ b/resources/json_schema.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "description": "<h2>Overview<\/h2>  Webhook for interfacing with FeedAMP",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "title": "Feedamp Webhook SDK",
         "contact": {
             "email": "feedamp@feedonomics.com"
@@ -2142,6 +2142,11 @@
                             },
                             "enable_graphql": {
                                 "description": "If enabled lookups will use the Shopify Graphql endpoint instead of the rest api endpoint",
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "use_mp_order_number_as_name": {
+                                "description": "If enabled, Marketplace Order Number will be submitted as the value for Name field when placing the Order.",
                                 "type": "boolean",
                                 "default": false
                             }

--- a/resources/openapi.yaml
+++ b/resources/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: <h2>Overview</h2>  Webhook for interfacing with FeedAMP
-  version: 0.1.2
+  version: 0.1.3
   title: Feedamp Webhook SDK
   contact:
     email: feedamp@feedonomics.com
@@ -1599,6 +1599,10 @@ components:
               default: true
             enable_graphql:
               description: If enabled lookups will use the Shopify Graphql endpoint instead of the rest api endpoint
+              type: boolean
+              default: false
+            use_mp_order_number_as_name:
+              description: If enabled, Marketplace Order Number will be submitted as the value for Name field when placing the Order.
               type: boolean
               default: false
       required:

--- a/src/services/ShopifyClient.php
+++ b/src/services/ShopifyClient.php
@@ -241,6 +241,7 @@ class ShopifyClient
             'include_order_line_additional_properties' => false,
             'marketplace_fulfilled_restrict_customer_info' => false,
             'enable_graphql' => false,
+            'use_mp_order_number_as_name' => false,
         ];
         if (!$configs) {
             return $defaults;
@@ -369,6 +370,9 @@ class ShopifyClient
         if ($config['use_note_attributes']) {
             $shopify_order['note'] = '';
             $shopify_order['note_attributes'] = $note_attributes;
+        }
+        if ($config['use_mp_order_number_as_name']) {
+            $shopify_order['name'] = $order['mp_order_number'];
         }
 
         $order_has_complete_billing_info = $this->is_order_billing_info_complete($order);


### PR DESCRIPTION
-Add name field to ShopifyClient order placement
-Add description of new use_mp_order_number_as_name config in yaml and json_schema

-Update yaml version number
-Update get_place_order_configs method in ShopifyClient